### PR TITLE
Fixing error when importing with less

### DIFF
--- a/vendor/styles/skylo.css
+++ b/vendor/styles/skylo.css
@@ -6,9 +6,9 @@
     background: none;
     z-index: 1000;
     border-radius: 0;
-    -webkit-border-radius: 0
-    -moz-border-radius: 0
-    -ms-border-radius: 0
+    -webkit-border-radius: 0;
+    -moz-border-radius: 0;
+    -ms-border-radius: 0;
 }
 
 .skylo .bar{


### PR DESCRIPTION
ParseError: Unrecognised input in client/libs/skylo/vendor/styles/skylo.css on line 9, column 5:

> > 8     border-radius: 0;
> > 9     -webkit-border-radius: 0
> > 10     -moz-border-radius: 0
